### PR TITLE
Don't fail on unexpected pubsub types

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -41,7 +41,8 @@ const handleBody = (body) => {
     case "OBJECT_FINALIZE":
       return handleFinalize(attributes);
     default:
-      return Promise.reject(new Error("Not a valid eventType"));
+      console.warn(`Unexpected event type ${attributes.eventType}`);
+      return Promise.resolve();
   }
 }
 

--- a/test/unit/connector.test.js
+++ b/test/unit/connector.test.js
@@ -138,4 +138,14 @@ describe("Connector", ()=>{
       assert.equal(code, CLIENT_ERROR_CODE)
     });
   });
+
+  it("acknowledges receipt for unexpected event types", ()=>{
+    req.body.message.attributes.eventType = "XXXX";
+
+    connector.handleRequest(req, res);
+
+    return resPromise.then(code=>{
+      assert.equal(code, SUCCESS_CODE)
+    });
+  });
 });


### PR DESCRIPTION
We shouldn't fail on these because google pubsub will then keep trying to resend.  We need to acknowledge and ignore (warn).